### PR TITLE
Add UTC telemetry for all domain objects

### DIFF
--- a/dsn/res/dsn-dictionary.json
+++ b/dsn/res/dsn-dictionary.json
@@ -82,6 +82,15 @@
                         },
                         "key": "cdscc.friendly.name",
                         "name": "Friendly name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -101,6 +110,15 @@
                         },
                         "key": "cdscc.latitude",
                         "name": "Latitude"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -120,6 +138,15 @@
                         },
                         "key": "cdscc.longitude",
                         "name": "Longitude"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -139,6 +166,15 @@
                         },
                         "key": "cdscc.name",
                         "name": "Name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -193,8 +229,9 @@
                         "hints": {
                             "domain": 1
                         },
-                        "key": "cdscc.utc.time",
-                        "name": "UTC time"
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     },
                     {
                         "hints": {
@@ -221,6 +258,15 @@
                         },
                         "key": "cdscc.time.zone.offset",
                         "name": "Time zone offset"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -231,7 +277,7 @@
                 "key": "cdscc.utc.time",
                 "namespace": "deep.space.network"
             },
-            "name": "UTC time",
+            "name": "UTC",
             "telemetry": {
                 "values": [
                     {
@@ -239,8 +285,9 @@
                         "hints": {
                             "domain": 1
                         },
-                        "key": "cdscc.utc.time",
-                        "name": "UTC time"
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -5604,6 +5651,15 @@
                         },
                         "key": "gdscc.friendly.name",
                         "name": "Friendly name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -5623,6 +5679,15 @@
                         },
                         "key": "gdscc.latitude",
                         "name": "Latitude"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -5642,6 +5707,15 @@
                         },
                         "key": "gdscc.longitude",
                         "name": "Longitude"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -5661,6 +5735,15 @@
                         },
                         "key": "gdscc.name",
                         "name": "Name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -5715,8 +5798,9 @@
                         "hints": {
                             "domain": 1
                         },
-                        "key": "gdscc.utc.time",
-                        "name": "UTC time"
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     },
                     {
                         "hints": {
@@ -5743,6 +5827,15 @@
                         },
                         "key": "gdscc.time.zone.offset",
                         "name": "Time zone offset"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -5753,7 +5846,7 @@
                 "key": "gdscc.utc.time",
                 "namespace": "deep.space.network"
             },
-            "name": "UTC time",
+            "name": "UTC",
             "telemetry": {
                 "values": [
                     {
@@ -5761,8 +5854,9 @@
                         "hints": {
                             "domain": 1
                         },
-                        "key": "gdscc.utc.time",
-                        "name": "UTC time"
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -5866,6 +5960,15 @@
                         },
                         "key": "mdscc.friendly.name",
                         "name": "Friendly name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5885,6 +5988,15 @@
                         },
                         "key": "mdscc.latitude",
                         "name": "Latitude"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5904,6 +6016,15 @@
                         },
                         "key": "mdscc.longitude",
                         "name": "Longitude"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5923,6 +6044,15 @@
                         },
                         "key": "mdscc.name",
                         "name": "Name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5977,8 +6107,9 @@
                         "hints": {
                             "domain": 1
                         },
-                        "key": "mdscc.utc.time",
-                        "name": "UTC time"
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     },
                     {
                         "hints": {
@@ -6005,6 +6136,15 @@
                         },
                         "key": "mdscc.time.zone.offset",
                         "name": "Time zone offset"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -6015,7 +6155,7 @@
                 "key": "mdscc.utc.time",
                 "namespace": "deep.space.network"
             },
-            "name": "UTC time",
+            "name": "UTC",
             "telemetry": {
                 "values": [
                     {
@@ -6023,8 +6163,9 @@
                         "hints": {
                             "domain": 1
                         },
-                        "key": "mdscc.utc.time",
-                        "name": "UTC time"
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },

--- a/dsn/res/dsn-dictionary.json
+++ b/dsn/res/dsn-dictionary.json
@@ -694,6 +694,15 @@
                         },
                         "key": "dss14.signal.power",
                         "name": "Power"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1244,6 +1253,15 @@
                         },
                         "key": "dss24.signal.power",
                         "name": "Power"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1794,6 +1812,15 @@
                         },
                         "key": "dss25.signal.power",
                         "name": "Power"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -2344,6 +2371,15 @@
                         },
                         "key": "dss26.signal.power",
                         "name": "Power"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -2894,6 +2930,15 @@
                         },
                         "key": "dss34.signal.power",
                         "name": "Power"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3444,6 +3489,15 @@
                         },
                         "key": "dss35.signal.power",
                         "name": "Power"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3994,6 +4048,15 @@
                         },
                         "key": "dss36.signal.power",
                         "name": "Power"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -4544,6 +4607,15 @@
                         },
                         "key": "dss43.signal.power",
                         "name": "Power"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -5094,6 +5166,15 @@
                         },
                         "key": "dss54.signal.power",
                         "name": "Power"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5644,6 +5725,15 @@
                         },
                         "key": "dss55.signal.power",
                         "name": "Power"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -6194,6 +6284,15 @@
                         },
                         "key": "dss63.signal.power",
                         "name": "Power"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -6744,6 +6843,15 @@
                         },
                         "key": "dss65.signal.power",
                         "name": "Power"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },

--- a/dsn/res/dsn-dictionary.json
+++ b/dsn/res/dsn-dictionary.json
@@ -305,7 +305,8 @@
                 "deep.space.network:dss14.array",
                 "deep.space.network:dss14.ddor",
                 "deep.space.network:dss14.created",
-                "deep.space.network:dss14.updated"
+                "deep.space.network:dss14.updated",
+                "deep.space.network:gdscc.utc.time"
             ],
             "identifier": {
                 "key": "dss14.antenna",
@@ -391,6 +392,15 @@
                         },
                         "key": "dss14.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -410,6 +420,15 @@
                         },
                         "key": "dss14.array",
                         "name": "Array"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -431,6 +450,15 @@
                         "key": "dss14.azimuth.angle",
                         "name": "Azimuth",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -451,6 +479,15 @@
                         },
                         "key": "dss14.created",
                         "name": "Created"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -470,6 +507,15 @@
                         },
                         "key": "dss14.ddor",
                         "name": "DDOR"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -491,6 +537,15 @@
                         "key": "dss14.elevation.angle",
                         "name": "Elevation",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -510,6 +565,15 @@
                         },
                         "key": "dss14.friendly.name",
                         "name": "Friendly name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -529,6 +593,15 @@
                         },
                         "key": "dss14.mspa",
                         "name": "MSPA"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -548,6 +621,15 @@
                         },
                         "key": "dss14.name",
                         "name": "Name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -688,6 +770,15 @@
                         },
                         "key": "dss14.type",
                         "name": "Type"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -708,6 +799,15 @@
                         },
                         "key": "dss14.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -729,6 +829,15 @@
                         "key": "dss14.wind.speed",
                         "name": "Wind speed",
                         "units": "km/hr"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -746,7 +855,8 @@
                 "deep.space.network:dss24.array",
                 "deep.space.network:dss24.ddor",
                 "deep.space.network:dss24.created",
-                "deep.space.network:dss24.updated"
+                "deep.space.network:dss24.updated",
+                "deep.space.network:gdscc.utc.time"
             ],
             "identifier": {
                 "key": "dss24.antenna",
@@ -832,6 +942,15 @@
                         },
                         "key": "dss24.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -851,6 +970,15 @@
                         },
                         "key": "dss24.array",
                         "name": "Array"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -872,6 +1000,15 @@
                         "key": "dss24.azimuth.angle",
                         "name": "Azimuth",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -892,6 +1029,15 @@
                         },
                         "key": "dss24.created",
                         "name": "Created"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -911,6 +1057,15 @@
                         },
                         "key": "dss24.ddor",
                         "name": "DDOR"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -932,6 +1087,15 @@
                         "key": "dss24.elevation.angle",
                         "name": "Elevation",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -951,6 +1115,15 @@
                         },
                         "key": "dss24.friendly.name",
                         "name": "Friendly name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -970,6 +1143,15 @@
                         },
                         "key": "dss24.mspa",
                         "name": "MSPA"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -989,6 +1171,15 @@
                         },
                         "key": "dss24.name",
                         "name": "Name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1129,6 +1320,15 @@
                         },
                         "key": "dss24.type",
                         "name": "Type"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1149,6 +1349,15 @@
                         },
                         "key": "dss24.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1170,6 +1379,15 @@
                         "key": "dss24.wind.speed",
                         "name": "Wind speed",
                         "units": "km/hr"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1187,7 +1405,8 @@
                 "deep.space.network:dss25.array",
                 "deep.space.network:dss25.ddor",
                 "deep.space.network:dss25.created",
-                "deep.space.network:dss25.updated"
+                "deep.space.network:dss25.updated",
+                "deep.space.network:gdscc.utc.time"
             ],
             "identifier": {
                 "key": "dss25.antenna",
@@ -1273,6 +1492,15 @@
                         },
                         "key": "dss25.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1292,6 +1520,15 @@
                         },
                         "key": "dss25.array",
                         "name": "Array"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1313,6 +1550,15 @@
                         "key": "dss25.azimuth.angle",
                         "name": "Azimuth",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1333,6 +1579,15 @@
                         },
                         "key": "dss25.created",
                         "name": "Created"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1352,6 +1607,15 @@
                         },
                         "key": "dss25.ddor",
                         "name": "DDOR"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1373,6 +1637,15 @@
                         "key": "dss25.elevation.angle",
                         "name": "Elevation",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1392,6 +1665,15 @@
                         },
                         "key": "dss25.friendly.name",
                         "name": "Friendly name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1411,6 +1693,15 @@
                         },
                         "key": "dss25.mspa",
                         "name": "MSPA"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1430,6 +1721,15 @@
                         },
                         "key": "dss25.name",
                         "name": "Name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1570,6 +1870,15 @@
                         },
                         "key": "dss25.type",
                         "name": "Type"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1590,6 +1899,15 @@
                         },
                         "key": "dss25.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1611,6 +1929,15 @@
                         "key": "dss25.wind.speed",
                         "name": "Wind speed",
                         "units": "km/hr"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1628,7 +1955,8 @@
                 "deep.space.network:dss26.array",
                 "deep.space.network:dss26.ddor",
                 "deep.space.network:dss26.created",
-                "deep.space.network:dss26.updated"
+                "deep.space.network:dss26.updated",
+                "deep.space.network:gdscc.utc.time"
             ],
             "identifier": {
                 "key": "dss26.antenna",
@@ -1714,6 +2042,15 @@
                         },
                         "key": "dss26.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1733,6 +2070,15 @@
                         },
                         "key": "dss26.array",
                         "name": "Array"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1754,6 +2100,15 @@
                         "key": "dss26.azimuth.angle",
                         "name": "Azimuth",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1774,6 +2129,15 @@
                         },
                         "key": "dss26.created",
                         "name": "Created"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1793,6 +2157,15 @@
                         },
                         "key": "dss26.ddor",
                         "name": "DDOR"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1814,6 +2187,15 @@
                         "key": "dss26.elevation.angle",
                         "name": "Elevation",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1833,6 +2215,15 @@
                         },
                         "key": "dss26.friendly.name",
                         "name": "Friendly name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1852,6 +2243,15 @@
                         },
                         "key": "dss26.mspa",
                         "name": "MSPA"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1871,6 +2271,15 @@
                         },
                         "key": "dss26.name",
                         "name": "Name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -2011,6 +2420,15 @@
                         },
                         "key": "dss26.type",
                         "name": "Type"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -2031,6 +2449,15 @@
                         },
                         "key": "dss26.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -2052,6 +2479,15 @@
                         "key": "dss26.wind.speed",
                         "name": "Wind speed",
                         "units": "km/hr"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -2069,7 +2505,8 @@
                 "deep.space.network:dss34.array",
                 "deep.space.network:dss34.ddor",
                 "deep.space.network:dss34.created",
-                "deep.space.network:dss34.updated"
+                "deep.space.network:dss34.updated",
+                "deep.space.network:cdscc.utc.time"
             ],
             "identifier": {
                 "key": "dss34.antenna",
@@ -2155,6 +2592,15 @@
                         },
                         "key": "dss34.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2174,6 +2620,15 @@
                         },
                         "key": "dss34.array",
                         "name": "Array"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2195,6 +2650,15 @@
                         "key": "dss34.azimuth.angle",
                         "name": "Azimuth",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2215,6 +2679,15 @@
                         },
                         "key": "dss34.created",
                         "name": "Created"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2234,6 +2707,15 @@
                         },
                         "key": "dss34.ddor",
                         "name": "DDOR"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2255,6 +2737,15 @@
                         "key": "dss34.elevation.angle",
                         "name": "Elevation",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2274,6 +2765,15 @@
                         },
                         "key": "dss34.friendly.name",
                         "name": "Friendly name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2293,6 +2793,15 @@
                         },
                         "key": "dss34.mspa",
                         "name": "MSPA"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2312,6 +2821,15 @@
                         },
                         "key": "dss34.name",
                         "name": "Name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2452,6 +2970,15 @@
                         },
                         "key": "dss34.type",
                         "name": "Type"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2472,6 +2999,15 @@
                         },
                         "key": "dss34.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2493,6 +3029,15 @@
                         "key": "dss34.wind.speed",
                         "name": "Wind speed",
                         "units": "km/hr"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2510,7 +3055,8 @@
                 "deep.space.network:dss35.array",
                 "deep.space.network:dss35.ddor",
                 "deep.space.network:dss35.created",
-                "deep.space.network:dss35.updated"
+                "deep.space.network:dss35.updated",
+                "deep.space.network:cdscc.utc.time"
             ],
             "identifier": {
                 "key": "dss35.antenna",
@@ -2596,6 +3142,15 @@
                         },
                         "key": "dss35.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2615,6 +3170,15 @@
                         },
                         "key": "dss35.array",
                         "name": "Array"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2636,6 +3200,15 @@
                         "key": "dss35.azimuth.angle",
                         "name": "Azimuth",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2656,6 +3229,15 @@
                         },
                         "key": "dss35.created",
                         "name": "Created"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2675,6 +3257,15 @@
                         },
                         "key": "dss35.ddor",
                         "name": "DDOR"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2696,6 +3287,15 @@
                         "key": "dss35.elevation.angle",
                         "name": "Elevation",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2715,6 +3315,15 @@
                         },
                         "key": "dss35.friendly.name",
                         "name": "Friendly name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2734,6 +3343,15 @@
                         },
                         "key": "dss35.mspa",
                         "name": "MSPA"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2753,6 +3371,15 @@
                         },
                         "key": "dss35.name",
                         "name": "Name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2893,6 +3520,15 @@
                         },
                         "key": "dss35.type",
                         "name": "Type"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2913,6 +3549,15 @@
                         },
                         "key": "dss35.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2934,6 +3579,15 @@
                         "key": "dss35.wind.speed",
                         "name": "Wind speed",
                         "units": "km/hr"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -2951,7 +3605,8 @@
                 "deep.space.network:dss36.array",
                 "deep.space.network:dss36.ddor",
                 "deep.space.network:dss36.created",
-                "deep.space.network:dss36.updated"
+                "deep.space.network:dss36.updated",
+                "deep.space.network:cdscc.utc.time"
             ],
             "identifier": {
                 "key": "dss36.antenna",
@@ -3037,6 +3692,15 @@
                         },
                         "key": "dss36.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3056,6 +3720,15 @@
                         },
                         "key": "dss36.array",
                         "name": "Array"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3077,6 +3750,15 @@
                         "key": "dss36.azimuth.angle",
                         "name": "Azimuth",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3097,6 +3779,15 @@
                         },
                         "key": "dss36.created",
                         "name": "Created"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3116,6 +3807,15 @@
                         },
                         "key": "dss36.ddor",
                         "name": "DDOR"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3137,6 +3837,15 @@
                         "key": "dss36.elevation.angle",
                         "name": "Elevation",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3156,6 +3865,15 @@
                         },
                         "key": "dss36.friendly.name",
                         "name": "Friendly name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3175,6 +3893,15 @@
                         },
                         "key": "dss36.mspa",
                         "name": "MSPA"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3194,6 +3921,15 @@
                         },
                         "key": "dss36.name",
                         "name": "Name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3334,6 +4070,15 @@
                         },
                         "key": "dss36.type",
                         "name": "Type"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3354,6 +4099,15 @@
                         },
                         "key": "dss36.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3375,6 +4129,15 @@
                         "key": "dss36.wind.speed",
                         "name": "Wind speed",
                         "units": "km/hr"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3392,7 +4155,8 @@
                 "deep.space.network:dss43.array",
                 "deep.space.network:dss43.ddor",
                 "deep.space.network:dss43.created",
-                "deep.space.network:dss43.updated"
+                "deep.space.network:dss43.updated",
+                "deep.space.network:cdscc.utc.time"
             ],
             "identifier": {
                 "key": "dss43.antenna",
@@ -3478,6 +4242,15 @@
                         },
                         "key": "dss43.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3497,6 +4270,15 @@
                         },
                         "key": "dss43.array",
                         "name": "Array"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3518,6 +4300,15 @@
                         "key": "dss43.azimuth.angle",
                         "name": "Azimuth",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3538,6 +4329,15 @@
                         },
                         "key": "dss43.created",
                         "name": "Created"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3557,6 +4357,15 @@
                         },
                         "key": "dss43.ddor",
                         "name": "DDOR"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3578,6 +4387,15 @@
                         "key": "dss43.elevation.angle",
                         "name": "Elevation",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3597,6 +4415,15 @@
                         },
                         "key": "dss43.friendly.name",
                         "name": "Friendly name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3616,6 +4443,15 @@
                         },
                         "key": "dss43.mspa",
                         "name": "MSPA"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3635,6 +4471,15 @@
                         },
                         "key": "dss43.name",
                         "name": "Name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3775,6 +4620,15 @@
                         },
                         "key": "dss43.type",
                         "name": "Type"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3795,6 +4649,15 @@
                         },
                         "key": "dss43.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3816,6 +4679,15 @@
                         "key": "dss43.wind.speed",
                         "name": "Wind speed",
                         "units": "km/hr"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3833,7 +4705,8 @@
                 "deep.space.network:dss54.array",
                 "deep.space.network:dss54.ddor",
                 "deep.space.network:dss54.created",
-                "deep.space.network:dss54.updated"
+                "deep.space.network:dss54.updated",
+                "deep.space.network:mdscc.utc.time"
             ],
             "identifier": {
                 "key": "dss54.antenna",
@@ -3919,6 +4792,15 @@
                         },
                         "key": "dss54.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -3938,6 +4820,15 @@
                         },
                         "key": "dss54.array",
                         "name": "Array"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -3959,6 +4850,15 @@
                         "key": "dss54.azimuth.angle",
                         "name": "Azimuth",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -3979,6 +4879,15 @@
                         },
                         "key": "dss54.created",
                         "name": "Created"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -3998,6 +4907,15 @@
                         },
                         "key": "dss54.ddor",
                         "name": "DDOR"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4019,6 +4937,15 @@
                         "key": "dss54.elevation.angle",
                         "name": "Elevation",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4038,6 +4965,15 @@
                         },
                         "key": "dss54.friendly.name",
                         "name": "Friendly name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4057,6 +4993,15 @@
                         },
                         "key": "dss54.mspa",
                         "name": "MSPA"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4076,6 +5021,15 @@
                         },
                         "key": "dss54.name",
                         "name": "Name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4216,6 +5170,15 @@
                         },
                         "key": "dss54.type",
                         "name": "Type"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4236,6 +5199,15 @@
                         },
                         "key": "dss54.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4257,6 +5229,15 @@
                         "key": "dss54.wind.speed",
                         "name": "Wind speed",
                         "units": "km/hr"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4274,7 +5255,8 @@
                 "deep.space.network:dss55.array",
                 "deep.space.network:dss55.ddor",
                 "deep.space.network:dss55.created",
-                "deep.space.network:dss55.updated"
+                "deep.space.network:dss55.updated",
+                "deep.space.network:mdscc.utc.time"
             ],
             "identifier": {
                 "key": "dss55.antenna",
@@ -4360,6 +5342,15 @@
                         },
                         "key": "dss55.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4379,6 +5370,15 @@
                         },
                         "key": "dss55.array",
                         "name": "Array"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4400,6 +5400,15 @@
                         "key": "dss55.azimuth.angle",
                         "name": "Azimuth",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4420,6 +5429,15 @@
                         },
                         "key": "dss55.created",
                         "name": "Created"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4439,6 +5457,15 @@
                         },
                         "key": "dss55.ddor",
                         "name": "DDOR"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4460,6 +5487,15 @@
                         "key": "dss55.elevation.angle",
                         "name": "Elevation",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4479,6 +5515,15 @@
                         },
                         "key": "dss55.friendly.name",
                         "name": "Friendly name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4498,6 +5543,15 @@
                         },
                         "key": "dss55.mspa",
                         "name": "MSPA"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4517,6 +5571,15 @@
                         },
                         "key": "dss55.name",
                         "name": "Name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4657,6 +5720,15 @@
                         },
                         "key": "dss55.type",
                         "name": "Type"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4677,6 +5749,15 @@
                         },
                         "key": "dss55.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4698,6 +5779,15 @@
                         "key": "dss55.wind.speed",
                         "name": "Wind speed",
                         "units": "km/hr"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4715,7 +5805,8 @@
                 "deep.space.network:dss63.array",
                 "deep.space.network:dss63.ddor",
                 "deep.space.network:dss63.created",
-                "deep.space.network:dss63.updated"
+                "deep.space.network:dss63.updated",
+                "deep.space.network:mdscc.utc.time"
             ],
             "identifier": {
                 "key": "dss63.antenna",
@@ -4801,6 +5892,15 @@
                         },
                         "key": "dss63.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4820,6 +5920,15 @@
                         },
                         "key": "dss63.array",
                         "name": "Array"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4841,6 +5950,15 @@
                         "key": "dss63.azimuth.angle",
                         "name": "Azimuth",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4861,6 +5979,15 @@
                         },
                         "key": "dss63.created",
                         "name": "Created"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4880,6 +6007,15 @@
                         },
                         "key": "dss63.ddor",
                         "name": "DDOR"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4901,6 +6037,15 @@
                         "key": "dss63.elevation.angle",
                         "name": "Elevation",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4920,6 +6065,15 @@
                         },
                         "key": "dss63.friendly.name",
                         "name": "Friendly name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4939,6 +6093,15 @@
                         },
                         "key": "dss63.mspa",
                         "name": "MSPA"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -4958,6 +6121,15 @@
                         },
                         "key": "dss63.name",
                         "name": "Name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5098,6 +6270,15 @@
                         },
                         "key": "dss63.type",
                         "name": "Type"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5118,6 +6299,15 @@
                         },
                         "key": "dss63.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5139,6 +6329,15 @@
                         "key": "dss63.wind.speed",
                         "name": "Wind speed",
                         "units": "km/hr"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5156,7 +6355,8 @@
                 "deep.space.network:dss65.array",
                 "deep.space.network:dss65.ddor",
                 "deep.space.network:dss65.created",
-                "deep.space.network:dss65.updated"
+                "deep.space.network:dss65.updated",
+                "deep.space.network:mdscc.utc.time"
             ],
             "identifier": {
                 "key": "dss65.antenna",
@@ -5242,6 +6442,15 @@
                         },
                         "key": "dss65.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5261,6 +6470,15 @@
                         },
                         "key": "dss65.array",
                         "name": "Array"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5282,6 +6500,15 @@
                         "key": "dss65.azimuth.angle",
                         "name": "Azimuth",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5302,6 +6529,15 @@
                         },
                         "key": "dss65.created",
                         "name": "Created"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5321,6 +6557,15 @@
                         },
                         "key": "dss65.ddor",
                         "name": "DDOR"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5342,6 +6587,15 @@
                         "key": "dss65.elevation.angle",
                         "name": "Elevation",
                         "units": "deg"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5361,6 +6615,15 @@
                         },
                         "key": "dss65.friendly.name",
                         "name": "Friendly name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5380,6 +6643,15 @@
                         },
                         "key": "dss65.mspa",
                         "name": "MSPA"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5399,6 +6671,15 @@
                         },
                         "key": "dss65.name",
                         "name": "Name"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5539,6 +6820,15 @@
                         },
                         "key": "dss65.type",
                         "name": "Type"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5559,6 +6849,15 @@
                         },
                         "key": "dss65.updated",
                         "name": "Updated"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5580,6 +6879,15 @@
                         "key": "dss65.wind.speed",
                         "name": "Wind speed",
                         "units": "km/hr"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },

--- a/dsn/res/dsn-dictionary.json
+++ b/dsn/res/dsn-dictionary.json
@@ -7705,11 +7705,13 @@
             "telemetry": {
                 "values": [
                     {
+                        "format": "utc",
                         "hints": {
                             "domain": 1
                         },
-                        "key": "timestamp",
-                        "name": "Timestamp"
+                        "key": "utc",
+                        "name": "Timestamp",
+                        "source": "timestamp"
                     }
                 ]
             },

--- a/dsn/res/dsn-dictionary.json
+++ b/dsn/res/dsn-dictionary.json
@@ -760,6 +760,15 @@
                         },
                         "key": "dss14.target.rtlt",
                         "name": "Round-trip light time"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1319,6 +1328,15 @@
                         },
                         "key": "dss24.target.rtlt",
                         "name": "Round-trip light time"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -1878,6 +1896,15 @@
                         },
                         "key": "dss25.target.rtlt",
                         "name": "Round-trip light time"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -2437,6 +2464,15 @@
                         },
                         "key": "dss26.target.rtlt",
                         "name": "Round-trip light time"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "gdscc.utc.time"
                     }
                 ]
             },
@@ -2996,6 +3032,15 @@
                         },
                         "key": "dss34.target.rtlt",
                         "name": "Round-trip light time"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -3555,6 +3600,15 @@
                         },
                         "key": "dss35.target.rtlt",
                         "name": "Round-trip light time"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -4114,6 +4168,15 @@
                         },
                         "key": "dss36.target.rtlt",
                         "name": "Round-trip light time"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -4673,6 +4736,15 @@
                         },
                         "key": "dss43.target.rtlt",
                         "name": "Round-trip light time"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "cdscc.utc.time"
                     }
                 ]
             },
@@ -5232,6 +5304,15 @@
                         },
                         "key": "dss54.target.rtlt",
                         "name": "Round-trip light time"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -5791,6 +5872,15 @@
                         },
                         "key": "dss55.target.rtlt",
                         "name": "Round-trip light time"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -6350,6 +6440,15 @@
                         },
                         "key": "dss63.target.rtlt",
                         "name": "Round-trip light time"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },
@@ -6909,6 +7008,15 @@
                         },
                         "key": "dss65.target.rtlt",
                         "name": "Round-trip light time"
+                    },
+                    {
+                        "format": "utc",
+                        "hints": {
+                            "domain": 1
+                        },
+                        "key": "utc",
+                        "name": "UTC",
+                        "source": "mdscc.utc.time"
                     }
                 ]
             },

--- a/dsn/src/DsnParser.js
+++ b/dsn/src/DsnParser.js
@@ -213,6 +213,7 @@ define([
                 signal[key + '.signal.spacecraft'] = child.getAttribute('spacecraft');
                 signal[key + '.signal.spacecraft.id'] = DsnUtils.parseTelemetryAsIntegerOrString(child, 'spacecraftId');
                 signal[key + '.signal.spacecraft.friendly.name'] = this.dsn.data[spacecraftName + '.friendly.name'];
+                signal = Object.assign(signal, utcTime);
                 dish[key + '.signals'].push(signal);
                 break;
             case 'target':

--- a/dsn/src/DsnParser.js
+++ b/dsn/src/DsnParser.js
@@ -38,8 +38,8 @@ define([
 
             sites[siteKey + '.name'] = siteElement.getAttribute('name');
             sites[siteKey + '.friendly.name'] = siteElement.getAttribute('friendlyName');
-            sites[siteKey + '.longitude'] = parseFloat(siteElement.getAttribute('longitude'));
-            sites[siteKey + '.latitude'] = parseFloat(siteElement.getAttribute('latitude'));
+            sites[siteKey + '.station.longitude'] = parseFloat(siteElement.getAttribute('longitude'));
+            sites[siteKey + '.station.latitude'] = parseFloat(siteElement.getAttribute('latitude'));
 
             for (var j = 0; j < siteElement.children.length; j++) {
                 dishElement = siteElement.children[j];
@@ -111,15 +111,28 @@ define([
      * @returns {object} An object containing the station's data.
      */
     DsnParser.prototype.parseStationTag = function (stationElement) {
-        var key = stationElement.getAttribute('name').toLowerCase(),
-            station = {};
+        var friendlyName = {},
+            key = stationElement.getAttribute('name').toLowerCase(),
+            latitude = {},
+            longitude = {},
+            name = {},
+            station = {},
+            timeZoneOffset = {},
+            utcTime = {};
 
-        station[key + '.name'] = stationElement.getAttribute('name');
-        station[key + '.friendly.name'] = stationElement.getAttribute('friendlyName');
-        station[key + '.utc.time'] = parseInt(stationElement.getAttribute('timeUTC'), 10);
-        station[key + '.time.zone.offset'] = parseInt(stationElement.getAttribute('timeZoneOffset'), 10);
-        station[key + '.longitude'] = this.dsn.data[key + '.longitude'];
-        station[key + '.latitude'] = this.dsn.data[key + '.latitude'];
+        name[key + '.name'] = stationElement.getAttribute('name');
+        friendlyName[key + '.friendly.name'] = stationElement.getAttribute('friendlyName');
+        utcTime[key + '.utc.time'] = parseInt(stationElement.getAttribute('timeUTC'), 10);
+        timeZoneOffset[key + '.time.zone.offset'] = parseInt(stationElement.getAttribute('timeZoneOffset'), 10);
+        longitude[key + '.longitude'] = this.dsn.data[key + '.station.longitude'];
+        latitude[key + '.latitude'] = this.dsn.data[key + '.station.latitude'];
+
+        station[key + '.name'] = Object.assign({}, name, utcTime);
+        station[key + '.friendly.name'] = Object.assign({}, friendlyName, utcTime);
+        station[key + '.utc.time'] = Object.assign({}, utcTime);
+        station[key + '.time.zone.offset'] = Object.assign({}, timeZoneOffset, utcTime);
+        station[key + '.longitude'] = Object.assign({}, longitude, utcTime);
+        station[key + '.latitude'] = Object.assign({}, latitude, utcTime);
         station[key + '.station'] = Object.assign({}, station);
 
         return station;

--- a/dsn/src/DsnParser.js
+++ b/dsn/src/DsnParser.js
@@ -226,6 +226,7 @@ define([
                 target[key + '.target.downleg.range'] = DsnUtils.parseTelemetryAsFloatOrString(child, 'downlegRange');
                 target[key + '.target.rtlt'] = DsnUtils.parseTelemetryAsFloatOrString(child, 'rtlt');
                 target[key + '.target.friendly.name'] = targetName ? this.dsn.data[targetName + '.friendly.name'] : '';
+                target = Object.assign(target, utcTime);
                 dish[key + '.targets'].push(target);
                 break;
             }

--- a/dsn/src/DsnParser.js
+++ b/dsn/src/DsnParser.js
@@ -46,8 +46,8 @@ define([
                 dishKey = dishElement.getAttribute('name').toLowerCase();
 
                 sites[dishKey + '.name'] = dishElement.getAttribute('name');
-                sites[dishKey + '.friendly.name'] = dishElement.getAttribute('friendlyName');
-                sites[dishKey + '.type'] = dishElement.getAttribute('type');
+                sites[dishKey + '.dish.friendly.name'] = dishElement.getAttribute('friendlyName');
+                sites[dishKey + '.dish.type'] = dishElement.getAttribute('type');
             }
         }
 
@@ -147,24 +147,51 @@ define([
      * up signals and targets.
      */
     DsnParser.prototype.parseDishTag = function (dishElement) {
-        var children = dishElement.children,
+        var azimuthAngle = {},
+            children = dishElement.children,
+            created = {},
+            dish = {},
+            elevationAngle = {},
+            friendlyName = {},
+            isArray = {},
+            isDdor = {},
+            isMspa = {},
             key,
-            dish = {};
+            name = {},
+            stationKey,
+            type = {},
+            updated = {},
+            utcTime,
+            windSpeed = {};
 
         key = dishElement.getAttribute('name').toLowerCase();
+        stationKey = DsnUtils.getStationNameByDish(key);
+        utcTime = this.dsn.data[stationKey + '.utc.time'];
 
-        dish[key + '.name'] = dishElement.getAttribute('name');
-        dish[key + '.friendly.name'] = this.dsn.data[key + '.friendly.name'];
-        dish[key + '.type'] = this.dsn.data[key + '.type'];
-        dish[key + '.azimuth.angle'] = DsnUtils.parseTelemetryAsFloatOrString(dishElement, 'azimuthAngle');
-        dish[key + '.elevation.angle'] = DsnUtils.parseTelemetryAsFloatOrString(dishElement, 'elevationAngle');
-        dish[key + '.wind.speed'] = DsnUtils.parseTelemetryAsFloatOrString(dishElement, 'windSpeed');
-        dish[key + '.mspa'] = dishElement.getAttribute('isMSPA') === 'true';
-        dish[key + '.array'] = dishElement.getAttribute('isArray') === 'true';
-        dish[key + '.ddor'] = dishElement.getAttribute('isDDOR') === 'true';
-        dish[key + '.created'] = dishElement.getAttribute('created');
-        dish[key + '.updated'] = dishElement.getAttribute('updated');
-        dish[key + '.antenna'] = Object.assign({}, dish);
+        name[key + '.name'] = dishElement.getAttribute('name');
+        friendlyName[key + '.friendly.name'] = this.dsn.data[key + '.dish.friendly.name'];
+        type[key + '.type'] = this.dsn.data[key + '.dish.type'];
+        azimuthAngle[key + '.azimuth.angle'] = DsnUtils.parseTelemetryAsFloatOrString(dishElement, 'azimuthAngle');
+        elevationAngle[key + '.elevation.angle'] = DsnUtils.parseTelemetryAsFloatOrString(dishElement, 'elevationAngle');
+        windSpeed[key + '.wind.speed'] = DsnUtils.parseTelemetryAsFloatOrString(dishElement, 'windSpeed');
+        isMspa[key + '.mspa'] = dishElement.getAttribute('isMSPA') === 'true';
+        isArray[key + '.array'] = dishElement.getAttribute('isArray') === 'true';
+        isDdor[key + '.ddor'] = dishElement.getAttribute('isDDOR') === 'true';
+        created[key + '.created'] = dishElement.getAttribute('created');
+        updated[key + '.updated'] = dishElement.getAttribute('updated');
+
+        dish[key + '.name'] = Object.assign({}, name, utcTime);
+        dish[key + '.friendly.name'] = Object.assign({}, friendlyName, utcTime);
+        dish[key + '.type'] = Object.assign({}, type, utcTime);
+        dish[key + '.azimuth.angle'] = Object.assign({}, azimuthAngle, utcTime);
+        dish[key + '.elevation.angle'] = Object.assign({}, elevationAngle, utcTime);
+        dish[key + '.wind.speed'] = Object.assign({}, windSpeed, utcTime);
+        dish[key + '.mspa'] = Object.assign({}, isMspa, utcTime);
+        dish[key + '.array'] = Object.assign({}, isArray, utcTime);
+        dish[key + '.ddor'] = Object.assign({}, isDdor, utcTime);
+        dish[key + '.created'] = Object.assign({}, created, utcTime);
+        dish[key + '.updated'] = Object.assign({}, updated, utcTime);
+        dish[key + '.antenna'] = Object.assign({}, dish, utcTime);
         dish[key + '.signals'] = [];
         dish[key + '.targets'] = [];
 

--- a/dsn/src/DsnUtils.js
+++ b/dsn/src/DsnUtils.js
@@ -6,12 +6,41 @@
  * need to be separated by a colon (eg. 'my.namespace:my.key').
  * @returns {Object} identifier
  */
-export const deserializeIdentifier = identifier => {
+ export const deserializeIdentifier = identifier => {
     var tokens = identifier.split(':');
     return {
         namespace: tokens[0],
         key: tokens[1]
     };
+}
+
+/**
+ * Returns the name of a station given the name of a dish.
+ *
+ * @param {string} dish - The name of a dish (eg. 'dss14').
+ * @returns {string} The station name (eg. 'gdscc').
+ */
+export const getStationNameByDish = dish => {
+    switch (dish.toLowerCase()) {
+        case 'dss14':
+        case 'dss24':
+        case 'dss25':
+        case 'dss26':
+            return 'gdscc'
+        case 'dss34':
+        case 'dss35':
+        case 'dss36':
+        case 'dss43':
+            return 'cdscc'
+        case 'dss54':
+        case 'dss55':
+        case 'dss56':
+        case 'dss63':
+        case 'dss65':
+            return 'mdscc'
+        default:
+            console.warn('Unknown dish: ', dish)
+    }
 }
 
 /**
@@ -51,6 +80,7 @@ export const serializeIdentifier = identifier => {
 
 export default {
     deserializeIdentifier: deserializeIdentifier,
+    getStationNameByDish: getStationNameByDish,
     parseTelemetryAsFloatOrString: parseTelemetryAsFloatOrString,
     parseTelemetryAsIntegerOrString: parseTelemetryAsIntegerOrString,
     serializeIdentifier: serializeIdentifier


### PR DESCRIPTION
This pull request adds UTC telemetry to all domain objects to satisfy the requirement that [all telemetry metadata must have a telemetry value with a key that matches the key of the active time system](https://github.com/nasa/openmct/blob/master/API.md#the-time-conductor-and-telemetry).

Each station element in the Deep Space Network's XML contains a `timeUTC` attribute.  This value is available through the corresponding domain object (eg. `mdscc.utc.time`) and is used for telemetry related to the station, dishes and the spacecraft receiving and sending signals.  The only domain object that doesn't use the station's UTC value is the timestamp associated with the XML response.

