### PR TITLE
Refactor tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build
+name: Build and test
 on: push
 jobs:
   build:
@@ -28,3 +28,6 @@ jobs:
 
       - name: Lint code
         run: npm run lint
+
+      - name: Run tests
+        run: npm run test

--- a/dsn/src/DsnParser.js
+++ b/dsn/src/DsnParser.js
@@ -204,6 +204,7 @@ define([
                 case 'upSignal':
                     spacecraftName = child.getAttribute('spacecraft').toLowerCase();
 
+                    signal = {};
                     signal[key + '.signal.direction'] = child.tagName.substring(0, child.tagName.length - 6);
                     signal[key + '.signal.type'] = child.getAttribute('signalType');
                     signal[key + '.signal.type.debug'] = child.getAttribute('signalTypeDebug');
@@ -219,6 +220,7 @@ define([
                 case 'target':
                     targetName = child.getAttribute('name').toLowerCase();
 
+                    target = {};
                     target[key + '.target.name'] = child.getAttribute('name');
                     target[key + '.target.id'] = DsnUtils.parseTelemetryAsIntegerOrString(child, 'id');
                     target[key + '.target.upleg.range'] = DsnUtils.parseTelemetryAsFloatOrString(child, 'uplegRange');

--- a/dsn/src/DsnParserSpec.js
+++ b/dsn/src/DsnParserSpec.js
@@ -3,12 +3,12 @@ import testXmlConfigResponse from '!!raw-loader!../res/test-dsn-config-response.
 import testXmlResponse from '!!raw-loader!../res/test-dsn-response.xml';
 
 describe('DsnParser', function () {
-    var domParser = new DOMParser();
+    const domParser = new DOMParser();
 
     describe('parses a response', function () {
-        var dsn,
-            dsnParser,
-            dsnXml;
+        let dsn;
+        let dsnParser;
+        let dsnXml;
 
         beforeAll(function () {
             dsnXml = domParser.parseFromString('<dsn></dsn>', 'application/xml');
@@ -29,10 +29,10 @@ describe('DsnParser', function () {
     });
 
     describe('parses a response', function () {
-        var dsn,
-            dsnParser,
-            dsnXml,
-            xml;
+        let dsn;
+        let dsnParser;
+        let dsnXml;
+        let xml;
 
         beforeAll(function () {
             xml = '<dsn><spacecraft id="1" name="VGR1" friendlyName="Voyager 1" /></dsn>';
@@ -54,9 +54,9 @@ describe('DsnParser', function () {
     });
 
     describe('parses a config response', function () {
-        var dsn,
-            dsnParser,
-            dsnXml;
+        let dsn;
+        let dsnParser;
+        let dsnXml;
 
         beforeAll(function () {
             dsnXml = domParser.parseFromString(testXmlConfigResponse, 'application/xml');
@@ -86,9 +86,9 @@ describe('DsnParser', function () {
     });
 
     describe('parses a response', function () {
-        var dsn,
-            dsnParser,
-            dsnXml;
+        let dsn;
+        let dsnParser;
+        let dsnXml;
 
         beforeAll(function () {
             dsnXml = domParser.parseFromString(testXmlResponse, 'application/xml');
@@ -112,9 +112,9 @@ describe('DsnParser', function () {
 
         describe('with a dish element', function () {
             it('containing signals and targets', function () {
-                var downSignal = {},
-                    upSignal = {},
-                    target = {};
+                let downSignal = {};
+                let upSignal = {};
+                let target = {};
 
                 expect(dsn.data['dss14.antenna']).toBeDefined();
                 expect(dsn.data['dss14.name']).toBe('DSS14');
@@ -161,8 +161,8 @@ describe('DsnParser', function () {
             });
 
             it('containing signals with no data rate, frequency or power', function () {
-                var mroDownSignal = dsn.data['dss35.signals'][1],
-                    tgoDownSignal = dsn.data['dss35.signals'][0];
+                const mroDownSignal = dsn.data['dss35.signals'][1];
+                const tgoDownSignal = dsn.data['dss35.signals'][0];
 
                 expect(mroDownSignal['dss35.signal.data.rate']).toBe('');
                 expect(mroDownSignal['dss35.signal.frequency']).toBe('');

--- a/dsn/src/DsnParserSpec.js
+++ b/dsn/src/DsnParserSpec.js
@@ -117,15 +117,15 @@ describe('DsnParser', function () {
                 let target = {};
 
                 expect(dsn.data['dss14.antenna']).toBeDefined();
-                expect(dsn.data['dss14.name']).toBe('DSS14');
-                expect(dsn.data['dss14.azimuth.angle']).toBe(86.24);
-                expect(dsn.data['dss14.elevation.angle']).toBe(15.91);
-                expect(dsn.data['dss14.wind.speed']).toBe(12.35);
-                expect(dsn.data['dss14.mspa']).toBe(false);
-                expect(dsn.data['dss14.array']).toBe(false);
-                expect(dsn.data['dss14.ddor']).toBe(false);
-                expect(dsn.data['dss14.created']).toBe('2019-02-09T09:35:17.496Z');
-                expect(dsn.data['dss14.updated']).toBe('2019-02-09T09:35:20.154Z');
+                expect(dsn.data['dss14.name']['dss14.name']).toBe('DSS14');
+                expect(dsn.data['dss14.azimuth.angle']['dss14.azimuth.angle']).toBe(86.24);
+                expect(dsn.data['dss14.elevation.angle']['dss14.elevation.angle']).toBe(15.91);
+                expect(dsn.data['dss14.wind.speed']['dss14.wind.speed']).toBe(12.35);
+                expect(dsn.data['dss14.mspa']['dss14.mspa']).toBe(false);
+                expect(dsn.data['dss14.array']['dss14.array']).toBe(false);
+                expect(dsn.data['dss14.ddor']['dss14.ddor']).toBe(false);
+                expect(dsn.data['dss14.created']['dss14.created']).toBe('2019-02-09T09:35:17.496Z');
+                expect(dsn.data['dss14.updated']['dss14.updated']).toBe('2019-02-09T09:35:20.154Z');
 
                 expect(dsn.data['dss14.signals']).toBeDefined();
 

--- a/dsn/src/DsnParserSpec.js
+++ b/dsn/src/DsnParserSpec.js
@@ -73,8 +73,8 @@ describe('DsnParser', function () {
         it('with a sites element', function () {
             expect(dsn.data['mdscc.name']).toBe('mdscc');
             expect(dsn.data['mdscc.friendly.name']).toBe('Madrid');
-            expect(dsn.data['mdscc.longitude']).toBe(-4.2480085);
-            expect(dsn.data['mdscc.latitude']).toBe(40.2413554);
+            expect(dsn.data['mdscc.station.longitude']).toBe(-4.2480085);
+            expect(dsn.data['mdscc.station.latitude']).toBe(40.2413554);
         });
 
         it('with a spacecraftMap element', function () {

--- a/dsn/src/DsnParserSpec.js
+++ b/dsn/src/DsnParserSpec.js
@@ -10,13 +10,13 @@ describe('DsnParser', function () {
         let dsnParser;
         let dsnXml;
 
-        beforeAll(function () {
+        beforeEach(function () {
             dsnXml = domParser.parseFromString('<dsn></dsn>', 'application/xml');
             dsnParser = new DsnParser();
             dsn = dsnParser.parseXml(dsnXml);
         });
 
-        afterAll(function () {
+        afterEach(function () {
             dsn = null;
             dsnParser = null;
             dsnXml = null;
@@ -34,14 +34,14 @@ describe('DsnParser', function () {
         let dsnXml;
         let xml;
 
-        beforeAll(function () {
+        beforeEach(function () {
             xml = '<dsn><spacecraft id="1" name="VGR1" friendlyName="Voyager 1" /></dsn>';
             dsnXml = domParser.parseFromString(xml, 'application/xml');
             dsnParser = new DsnParser();
             dsn = dsnParser.parseXml(dsnXml);
         });
 
-        afterAll(function () {
+        afterEach(function () {
             dsn = null;
             dsnParser = null;
             dsnXml = null;
@@ -58,13 +58,13 @@ describe('DsnParser', function () {
         let dsnParser;
         let dsnXml;
 
-        beforeAll(function () {
+        beforeEach(function () {
             dsnXml = domParser.parseFromString(testXmlConfigResponse, 'application/xml');
             dsnParser = new DsnParser();
             dsn = dsnParser.parseXml(dsnXml);
         });
 
-        afterAll(function () {
+        afterEach(function () {
             dsn = null;
             dsnParser = null;
             dsnXml = null;
@@ -90,13 +90,13 @@ describe('DsnParser', function () {
         let dsnParser;
         let dsnXml;
 
-        beforeAll(function () {
+        beforeEach(function () {
             dsnXml = domParser.parseFromString(testXmlResponse, 'application/xml');
             dsnParser = new DsnParser();
             dsn = dsnParser.parseXml(dsnXml);
         });
 
-        afterAll(function () {
+        afterEach(function () {
             dsn = null;
             dsnParser = null;
             dsnXml = null;

--- a/dsn/src/DsnParserSpec.js
+++ b/dsn/src/DsnParserSpec.js
@@ -104,10 +104,10 @@ describe('DsnParser', function () {
 
         it('with a station element', function () {
             expect(dsn.data['cdscc.station']).toBeDefined();
-            expect(dsn.data['cdscc.name']).toBe('cdscc');
-            expect(dsn.data['cdscc.friendly.name']).toBe('Canberra');
-            expect(dsn.data['cdscc.utc.time']).toBe(1549708172929);
-            expect(dsn.data['cdscc.time.zone.offset']).toBe(39600000);
+            expect(dsn.data['cdscc.name']['cdscc.name']).toBe('cdscc');
+            expect(dsn.data['cdscc.friendly.name']['cdscc.friendly.name']).toBe('Canberra');
+            expect(dsn.data['cdscc.utc.time']['cdscc.utc.time']).toBe(1549708172929);
+            expect(dsn.data['cdscc.time.zone.offset']['cdscc.time.zone.offset']).toBe(39600000);
         });
 
         describe('with a dish element', function () {

--- a/dsn/src/DsnParserSpec.js
+++ b/dsn/src/DsnParserSpec.js
@@ -1,188 +1,181 @@
+import DsnParser from './DsnParser.js';
+import testXmlConfigResponse from '!!raw-loader!../res/test-dsn-config-response.xml';
+import testXmlResponse from '!!raw-loader!../res/test-dsn-response.xml';
 
-define([
-    './DsnParser',
-    '../res/test-dsn-config-response.xml',
-    '../res/test-dsn-response.xml'
-], function (
-    DsnParser,
-    testXmlConfigResponse,
-    testXmlResponse
-) {
-    describe('DsnParser', function () {
-        var domParser = new DOMParser();
+describe('DsnParser', function () {
+    var domParser = new DOMParser();
 
-        describe('parses a response', function () {
-            var dsn,
-                dsnParser,
-                dsnXml;
+    describe('parses a response', function () {
+        var dsn,
+            dsnParser,
+            dsnXml;
 
-            beforeAll(function () {
-                dsnXml = domParser.parseFromString('<dsn></dsn>', 'application/xml');
-                dsnParser = new DsnParser();
-                dsn = dsnParser.parseXml(dsnXml);
+        beforeAll(function () {
+            dsnXml = domParser.parseFromString('<dsn></dsn>', 'application/xml');
+            dsnParser = new DsnParser();
+            dsn = dsnParser.parseXml(dsnXml);
+        });
+
+        afterAll(function () {
+            dsn = null;
+            dsnParser = null;
+            dsnXml = null;
+        });
+
+        it('with no child elements', function () {
+            expect(dsn.data).toBeDefined();
+            expect(Object.keys(dsn.data).length).toBe(0);
+        });
+    });
+
+    describe('parses a response', function () {
+        var dsn,
+            dsnParser,
+            dsnXml,
+            xml;
+
+        beforeAll(function () {
+            xml = '<dsn><spacecraft id="1" name="VGR1" friendlyName="Voyager 1" /></dsn>';
+            dsnXml = domParser.parseFromString(xml, 'application/xml');
+            dsnParser = new DsnParser();
+            dsn = dsnParser.parseXml(dsnXml);
+        });
+
+        afterAll(function () {
+            dsn = null;
+            dsnParser = null;
+            dsnXml = null;
+        });
+
+        it('with an unknown element', function () {
+            expect(dsn.data).toBeDefined();
+            expect(Object.keys(dsn.data).length).toBe(0);
+        });
+    });
+
+    describe('parses a config response', function () {
+        var dsn,
+            dsnParser,
+            dsnXml;
+
+        beforeAll(function () {
+            dsnXml = domParser.parseFromString(testXmlConfigResponse, 'application/xml');
+            dsnParser = new DsnParser();
+            dsn = dsnParser.parseXml(dsnXml);
+        });
+
+        afterAll(function () {
+            dsn = null;
+            dsnParser = null;
+            dsnXml = null;
+        });
+
+        it('with a sites element', function () {
+            expect(dsn.data['mdscc.name']).toBe('mdscc');
+            expect(dsn.data['mdscc.friendly.name']).toBe('Madrid');
+            expect(dsn.data['mdscc.longitude']).toBe(-4.2480085);
+            expect(dsn.data['mdscc.latitude']).toBe(40.2413554);
+        });
+
+        it('with a spacecraftMap element', function () {
+            expect(dsn.data['vgr2.name']).toBe('vgr2');
+            expect(dsn.data['vgr2.explorer.name']).toBe('sc_voyager_2');
+            expect(dsn.data['vgr2.friendly.name']).toBe('Voyager 2');
+            expect(dsn.data['vgr2.thumbnail']).toBe(true);
+        });
+    });
+
+    describe('parses a response', function () {
+        var dsn,
+            dsnParser,
+            dsnXml;
+
+        beforeAll(function () {
+            dsnXml = domParser.parseFromString(testXmlResponse, 'application/xml');
+            dsnParser = new DsnParser();
+            dsn = dsnParser.parseXml(dsnXml);
+        });
+
+        afterAll(function () {
+            dsn = null;
+            dsnParser = null;
+            dsnXml = null;
+        });
+
+        it('with a station element', function () {
+            expect(dsn.data['cdscc.station']).toBeDefined();
+            expect(dsn.data['cdscc.name']).toBe('cdscc');
+            expect(dsn.data['cdscc.friendly.name']).toBe('Canberra');
+            expect(dsn.data['cdscc.utc.time']).toBe(1549708172929);
+            expect(dsn.data['cdscc.time.zone.offset']).toBe(39600000);
+        });
+
+        describe('with a dish element', function () {
+            it('containing signals and targets', function () {
+                var downSignal = {},
+                    upSignal = {},
+                    target = {};
+
+                expect(dsn.data['dss14.antenna']).toBeDefined();
+                expect(dsn.data['dss14.name']).toBe('DSS14');
+                expect(dsn.data['dss14.azimuth.angle']).toBe(86.24);
+                expect(dsn.data['dss14.elevation.angle']).toBe(15.91);
+                expect(dsn.data['dss14.wind.speed']).toBe(12.35);
+                expect(dsn.data['dss14.mspa']).toBe(false);
+                expect(dsn.data['dss14.array']).toBe(false);
+                expect(dsn.data['dss14.ddor']).toBe(false);
+                expect(dsn.data['dss14.created']).toBe('2019-02-09T09:35:17.496Z');
+                expect(dsn.data['dss14.updated']).toBe('2019-02-09T09:35:20.154Z');
+
+                expect(dsn.data['dss14.signals']).toBeDefined();
+
+                downSignal = dsn.data['dss14.signals'][0];
+                expect(downSignal['dss14.signal.direction']).toBe('down');
+                expect(downSignal['dss14.signal.type']).toBe('data');
+                expect(downSignal['dss14.signal.type.debug']).toBe('IN LOCK OFF 1 MCD2');
+                expect(downSignal['dss14.signal.data.rate']).toBe(160.002853);
+                expect(downSignal['dss14.signal.frequency']).toBe(8420585323.254991);
+                expect(downSignal['dss14.signal.power']).toBe(-155.647873);
+                expect(downSignal['dss14.signal.spacecraft']).toBe('VGR1');
+                expect(downSignal['dss14.signal.spacecraft.id']).toBe(31);
+
+                upSignal = dsn.data['dss14.signals'][1];
+                expect(upSignal['dss14.signal.direction']).toBe('up');
+                expect(upSignal['dss14.signal.type']).toBe('none');
+                expect(upSignal['dss14.signal.type.debug']).toBe('none');
+                expect(upSignal['dss14.signal.data.rate']).toBe(160.002853);
+                expect(upSignal['dss14.signal.frequency']).toBe(8420585323.254991);
+                expect(upSignal['dss14.signal.power']).toBe(-155.647873);
+                expect(upSignal['dss14.signal.spacecraft']).toBe('');
+                expect(upSignal['dss14.signal.spacecraft.id']).toBe('');
+                expect(dsn.data['dss14.targets']).toBeDefined();
+
+                expect(dsn.data['dss14.targets']).toBeDefined();
+
+                target = dsn.data['dss14.targets'][0];
+                expect(target['dss14.target.name']).toBe('VGR1');
+                expect(target['dss14.target.id']).toBe(31);
+                expect(target['dss14.target.upleg.range']).toBe(21700581860.317);
+                expect(target['dss14.target.downleg.range']).toBe(21698131625.495);
+                expect(target['dss14.target.rtlt']).toBe(144764.894661);
             });
 
-            afterAll(function () {
-                dsn = null;
-                dsnParser = null;
-                dsnXml = null;
-            });
+            it('containing signals with no data rate, frequency or power', function () {
+                var mroDownSignal = dsn.data['dss35.signals'][1],
+                    tgoDownSignal = dsn.data['dss35.signals'][0];
 
-            it('with no child elements', function () {
-                expect(dsn.data).toBeDefined();
-                expect(Object.keys(dsn.data).length).toBe(0);
+                expect(mroDownSignal['dss35.signal.data.rate']).toBe('');
+                expect(mroDownSignal['dss35.signal.frequency']).toBe('');
+                expect(mroDownSignal['dss35.signal.power']).toBe('');
+
+                expect(tgoDownSignal['dss35.signal.data.rate']).toBe('none');
+                expect(tgoDownSignal['dss35.signal.frequency']).toBe('none');
+                expect(tgoDownSignal['dss35.signal.power']).toBe('none');
             });
         });
 
-        describe('parses a response', function () {
-            var dsn,
-                dsnParser,
-                dsnXml,
-                xml;
-
-            beforeAll(function () {
-                xml = '<dsn><spacecraft id="1" name="VGR1" friendlyName="Voyager 1" /></dsn>';
-                dsnXml = domParser.parseFromString(xml, 'application/xml');
-                dsnParser = new DsnParser();
-                dsn = dsnParser.parseXml(dsnXml);
-            });
-
-            afterAll(function () {
-                dsn = null;
-                dsnParser = null;
-                dsnXml = null;
-            });
-
-            it('with an unknown element', function () {
-                expect(dsn.data).toBeDefined();
-                expect(Object.keys(dsn.data).length).toBe(0);
-            });
-        });
-
-        describe('parses a config response', function () {
-            var dsn,
-                dsnParser,
-                dsnXml;
-
-            beforeAll(function () {
-                dsnXml = domParser.parseFromString(testXmlConfigResponse, 'application/xml');
-                dsnParser = new DsnParser();
-                dsn = dsnParser.parseXml(dsnXml);
-            });
-
-            afterAll(function () {
-                dsn = null;
-                dsnParser = null;
-                dsnXml = null;
-            });
-
-            it('with a sites element', function () {
-                expect(dsn.data['mdscc.name']).toBe('mdscc');
-                expect(dsn.data['mdscc.friendly.name']).toBe('Madrid');
-                expect(dsn.data['mdscc.longitude']).toBe(-4.2480085);
-                expect(dsn.data['mdscc.latitude']).toBe(40.2413554);
-            });
-
-            it('with a spacecraftMap element', function () {
-                expect(dsn.data['vgr2.name']).toBe('vgr2');
-                expect(dsn.data['vgr2.explorer.name']).toBe('sc_voyager_2');
-                expect(dsn.data['vgr2.friendly.name']).toBe('Voyager 2');
-                expect(dsn.data['vgr2.thumbnail']).toBe(true);
-            });
-        });
-
-        describe('parses a response', function () {
-            var dsn,
-                dsnParser,
-                dsnXml;
-
-            beforeAll(function () {
-                dsnXml = domParser.parseFromString(testXmlResponse, 'application/xml');
-                dsnParser = new DsnParser();
-                dsn = dsnParser.parseXml(dsnXml);
-            });
-
-            afterAll(function () {
-                dsn = null;
-                dsnParser = null;
-                dsnXml = null;
-            });
-
-            it('with a station element', function () {
-                expect(dsn.data['cdscc.station']).toBeDefined();
-                expect(dsn.data['cdscc.name']).toBe('cdscc');
-                expect(dsn.data['cdscc.friendly.name']).toBe('Canberra');
-                expect(dsn.data['cdscc.utc.time']).toBe(1549708172929);
-                expect(dsn.data['cdscc.time.zone.offset']).toBe(39600000);
-            });
-
-            describe('with a dish element', function () {
-                it('containing signals and targets', function () {
-                    var downSignal = {},
-                        upSignal = {},
-                        target = {};
-
-                    expect(dsn.data['dss14.antenna']).toBeDefined();
-                    expect(dsn.data['dss14.name']).toBe('DSS14');
-                    expect(dsn.data['dss14.azimuth.angle']).toBe(86.24);
-                    expect(dsn.data['dss14.elevation.angle']).toBe(15.91);
-                    expect(dsn.data['dss14.wind.speed']).toBe(12.35);
-                    expect(dsn.data['dss14.mspa']).toBe(false);
-                    expect(dsn.data['dss14.array']).toBe(false);
-                    expect(dsn.data['dss14.ddor']).toBe(false);
-                    expect(dsn.data['dss14.created']).toBe('2019-02-09T09:35:17.496Z');
-                    expect(dsn.data['dss14.updated']).toBe('2019-02-09T09:35:20.154Z');
-
-                    expect(dsn.data['dss14.signals']).toBeDefined();
-
-                    downSignal = dsn.data['dss14.signals'][0];
-                    expect(downSignal['dss14.signal.direction']).toBe('down');
-                    expect(downSignal['dss14.signal.type']).toBe('data');
-                    expect(downSignal['dss14.signal.type.debug']).toBe('IN LOCK OFF 1 MCD2');
-                    expect(downSignal['dss14.signal.data.rate']).toBe(160.002853);
-                    expect(downSignal['dss14.signal.frequency']).toBe(8420585323.254991);
-                    expect(downSignal['dss14.signal.power']).toBe(-155.647873);
-                    expect(downSignal['dss14.signal.spacecraft']).toBe('VGR1');
-                    expect(downSignal['dss14.signal.spacecraft.id']).toBe(31);
-
-                    upSignal = dsn.data['dss14.signals'][1];
-                    expect(upSignal['dss14.signal.direction']).toBe('up');
-                    expect(upSignal['dss14.signal.type']).toBe('none');
-                    expect(upSignal['dss14.signal.type.debug']).toBe('none');
-                    expect(upSignal['dss14.signal.data.rate']).toBe(160.002853);
-                    expect(upSignal['dss14.signal.frequency']).toBe(8420585323.254991);
-                    expect(upSignal['dss14.signal.power']).toBe(-155.647873);
-                    expect(upSignal['dss14.signal.spacecraft']).toBe('');
-                    expect(upSignal['dss14.signal.spacecraft.id']).toBe('');
-                    expect(dsn.data['dss14.targets']).toBeDefined();
-
-                    expect(dsn.data['dss14.targets']).toBeDefined();
-
-                    target = dsn.data['dss14.targets'][0];
-                    expect(target['dss14.target.name']).toBe('VGR1');
-                    expect(target['dss14.target.id']).toBe(31);
-                    expect(target['dss14.target.upleg.range']).toBe(21700581860.317);
-                    expect(target['dss14.target.downleg.range']).toBe(21698131625.495);
-                    expect(target['dss14.target.rtlt']).toBe(144764.894661);
-                });
-
-                it('containing signals with no data rate, frequency or power', function () {
-                    var mroDownSignal = dsn.data['dss35.signals'][1],
-                        tgoDownSignal = dsn.data['dss35.signals'][0];
-
-                    expect(mroDownSignal['dss35.signal.data.rate']).toBe('');
-                    expect(mroDownSignal['dss35.signal.frequency']).toBe('');
-                    expect(mroDownSignal['dss35.signal.power']).toBe('');
-
-                    expect(tgoDownSignal['dss35.signal.data.rate']).toBe('none');
-                    expect(tgoDownSignal['dss35.signal.frequency']).toBe('none');
-                    expect(tgoDownSignal['dss35.signal.power']).toBe('none');
-                });
-            });
-
-            it('with a timestamp element', function () {
-                expect(dsn.data.timestamp).toBe(1549708172928);
-            });
+        it('with a timestamp element', function () {
+            expect(dsn.data.timestamp).toBe(1549708172928);
         });
     });
 });

--- a/dsn/src/DsnUtilsSpec.js
+++ b/dsn/src/DsnUtilsSpec.js
@@ -2,13 +2,13 @@ import DsnUtils from './DsnUtils.js';
 
 describe('DsnUtils', function () {
     it('deserializes a domain object identifier', function () {
-        var identifier = DsnUtils.deserializeIdentifier('deep.space.network:canberra');
+        const identifier = DsnUtils.deserializeIdentifier('deep.space.network:canberra');
         expect(identifier.namespace).toBe('deep.space.network');
         expect(identifier.key).toBe('canberra');
     });
 
     it('serializes a domain object identifier', function () {
-        var identifer = DsnUtils.serializeIdentifier({
+        const identifer = DsnUtils.serializeIdentifier({
             namespace: 'deep.space.network',
             key: 'madrid'
         });
@@ -17,14 +17,14 @@ describe('DsnUtils', function () {
     });
 
     describe('parses telemetry', function () {
-        var downSignal;
+        let downSignal;
 
         beforeEach(function () {
             downSignal = document.createElement('downSignal');
         });
 
         it('as a float', function () {
-            var dataRate;
+            let dataRate;
 
             downSignal.setAttribute('dataRate', '160.002853');
             dataRate = DsnUtils.parseTelemetryAsFloatOrString(downSignal, 'dataRate');
@@ -32,9 +32,9 @@ describe('DsnUtils', function () {
         });
 
         it('as a string when a float can not be parsed', function () {
-            var dataRate,
-                frequency,
-                power;
+            let dataRate;
+            let frequency;
+            let power;
 
             downSignal.setAttribute('dataRate', '');
             downSignal.setAttribute('frequency', ' ');
@@ -50,7 +50,7 @@ describe('DsnUtils', function () {
         });
 
         it('as an integer', function () {
-            var dataRate;
+            let dataRate;
 
             downSignal.setAttribute('dataRate', '160');
             dataRate = DsnUtils.parseTelemetryAsIntegerOrString(downSignal, 'dataRate');
@@ -58,9 +58,9 @@ describe('DsnUtils', function () {
         });
 
         it('as a string when an integer can not be parsed', function () {
-            var dataRate,
-                frequency,
-                power;
+            let dataRate;
+            let frequency;
+            let power;
 
             downSignal.setAttribute('dataRate', '');
             downSignal.setAttribute('frequency', ' ');

--- a/dsn/src/DsnUtilsSpec.js
+++ b/dsn/src/DsnUtilsSpec.js
@@ -23,6 +23,10 @@ describe('DsnUtils', function () {
             downSignal = document.createElement('downSignal');
         });
 
+        afterEach(function () {
+            downSignal = null;
+        });
+
         it('as a float', function () {
             let dataRate;
 

--- a/dsn/src/DsnUtilsSpec.js
+++ b/dsn/src/DsnUtilsSpec.js
@@ -16,6 +16,95 @@ describe('DsnUtils', function () {
         expect(identifer).toBe('deep.space.network:madrid');
     });
 
+    describe('returns Goldstone station name for', function () {
+        let station;
+
+        afterEach(function () {
+            station = null;
+        });
+
+        it('DSS14', function () {
+            station = DsnUtils.getStationNameByDish('dss14');
+            expect(station).toBe('gdscc');
+        });
+
+        it('DSS24', function () {
+            station = DsnUtils.getStationNameByDish('dss24');
+            expect(station).toBe('gdscc');
+        });
+
+        it('DSS25', function () {
+            station = DsnUtils.getStationNameByDish('dss25');
+            expect(station).toBe('gdscc');
+        });
+
+        it('DSS26', function () {
+            station = DsnUtils.getStationNameByDish('dss26');
+            expect(station).toBe('gdscc');
+        });
+    });
+
+    describe('returns Canberra station name for', function () {
+        let station;
+
+        afterEach(function () {
+            station = null;
+        });
+
+        it('DSS34', function () {
+            station = DsnUtils.getStationNameByDish('dss34');
+            expect(station).toBe('cdscc');
+        });
+
+        it('DSS35', function () {
+            station = DsnUtils.getStationNameByDish('dss35');
+            expect(station).toBe('cdscc');
+        });
+
+        it('DSS36', function () {
+            station = DsnUtils.getStationNameByDish('dss36');
+            expect(station).toBe('cdscc');
+        });
+
+        it('DSS43', function () {
+            station = DsnUtils.getStationNameByDish('dss43');
+            expect(station).toBe('cdscc');
+        });
+    });
+
+    describe('returns Madrid station name for', function () {
+        let station;
+
+        afterEach(function () {
+            station = null;
+        });
+
+        it('DSS54', function () {
+            station = DsnUtils.getStationNameByDish('dss54');
+            expect(station).toBe('mdscc');
+        });
+
+        it('DSS55', function () {
+            station = DsnUtils.getStationNameByDish('dss55');
+            expect(station).toBe('mdscc');
+        });
+
+        it('DSS56', function () {
+            station = DsnUtils.getStationNameByDish('dss56');
+            expect(station).toBe('mdscc');
+        });
+
+        it('DSS63', function () {
+            station = DsnUtils.getStationNameByDish('dss63');
+            expect(station).toBe('mdscc');
+        });
+
+        it('DSS65', function () {
+            station = DsnUtils.getStationNameByDish('dss65');
+            expect(station).toBe('mdscc');
+        });
+    });
+
     describe('parses telemetry', function () {
         let downSignal;
 

--- a/dsn/src/DsnUtilsSpec.js
+++ b/dsn/src/DsnUtilsSpec.js
@@ -16,6 +16,12 @@ describe('DsnUtils', function () {
         expect(identifer).toBe('deep.space.network:madrid');
     });
 
+    it('logs a warning to the console when unknown dish is provided', function () {
+        spyOn(console, 'warn');
+        DsnUtils.getStationNameByDish('iss');
+        expect(console.warn).toHaveBeenCalled();
+    });
+
     describe('returns Goldstone station name for', function () {
         let station;
 

--- a/dsn/src/DsnUtilsSpec.js
+++ b/dsn/src/DsnUtilsSpec.js
@@ -1,4 +1,4 @@
-import DsnUtils from './DsnUtils.js'
+import DsnUtils from './DsnUtils.js';
 
 describe('DsnUtils', function () {
     it('deserializes a domain object identifier', function () {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "main": "plugin.js",
   "scripts": {
     "build": "webpack --config webpack.config.js",
-    "lint": "eslint . --ignore-pattern *Spec.js",
+    "lint": "eslint .",
     "test": "karma start --single-run",
     "test:debug": "NODE_ENV=debug karma start --no-single-run"
   },


### PR DESCRIPTION
This pull request:
- Fixes errors in test files raised by ESLint.
- Adds a step to the GitHub action to execute tests.
- Fixes a bug by assigning an empty object to the signal and target before data is parsed.
- Replaces the use of Jasmine's `beforeAll` with `beforeEach` to avoid leaking state between tests.  `afterAll` has also been replaced with `afterEach`.
- Adds tests to check that the correct station name is returned when given a dish's key.