### PR TITLE
Add indicator to show active antennas

### DIFF
--- a/dsn/src/DsnIndicator.js
+++ b/dsn/src/DsnIndicator.js
@@ -1,0 +1,49 @@
+import { CANBERRA_ANTENNAS, GOLDSTONE_ANTENNAS, MADRID_ANTENNAS } from './constants.js';
+
+class DsnIndicator {
+    constructor(openmct) {
+        this.indicator = openmct.indicators.simpleIndicator();
+        this.indicator.text('Deep Space Network');
+        this.indicator.description('Select telemetry item to fetch data.');
+        this.indicator.iconClass('icon-connectivity');
+    }
+
+    formatAntennaStatus(station, activeAntennas) {
+        let status = `${station}: ${activeAntennas.length}`;
+
+        if (activeAntennas.length > 0) {
+            const antennas = activeAntennas.flatMap(s => s.replace(/dss/, 'DSS '));
+            status += ` (${antennas.join(', ')})`;
+        }
+
+        return status;
+    }
+
+    getActiveAntennas(dsn, antennas) {
+        return antennas.filter(antenna => {
+            const key = antenna + '.signals';
+
+            return Object.prototype.hasOwnProperty.call(dsn.data, key) && dsn.data[key].length > 0;
+        });
+    }
+
+    setActiveAntennas(dsn) {
+        const activeCanberraAntennas = this.getActiveAntennas(dsn, CANBERRA_ANTENNAS);
+        const activeGoldstoneAntennas = this.getActiveAntennas(dsn, GOLDSTONE_ANTENNAS);
+        const activeMadridAntennas = this.getActiveAntennas(dsn, MADRID_ANTENNAS);
+
+        let status = this.formatAntennaStatus('Canberra', activeCanberraAntennas);
+        status += '\n' + this.formatAntennaStatus('Goldstone', activeGoldstoneAntennas);
+        status += '\n' + this.formatAntennaStatus('Madrid', activeMadridAntennas);
+
+        this.indicator.statusClass('s-status-ok');
+        this.indicator.description(status);
+    }
+
+    setError(error) {
+        this.indicator.statusClass('s-status-error');
+        this.indicator.description(error);
+    }
+}
+
+export default DsnIndicator;

--- a/dsn/src/DsnIndicatorSpec.js
+++ b/dsn/src/DsnIndicatorSpec.js
@@ -61,4 +61,10 @@ describe('DsnIndicator', function () {
         indicator.setActiveAntennas(dsn);
         expect(indicator.indicator.statusClass).toHaveBeenCalledWith(expected);
     });
+
+    it('updates the description when setting active antennas', function () {
+        const expected = 'Canberra: 0\nGoldstone: 1 (DSS 25)\nMadrid: 2 (DSS 54, DSS 55)';
+        indicator.setActiveAntennas(dsn);
+        expect(indicator.indicator.description).toHaveBeenCalledWith(expected);
+    });
 });

--- a/dsn/src/DsnIndicatorSpec.js
+++ b/dsn/src/DsnIndicatorSpec.js
@@ -67,4 +67,10 @@ describe('DsnIndicator', function () {
         indicator.setActiveAntennas(dsn);
         expect(indicator.indicator.description).toHaveBeenCalledWith(expected);
     });
+
+    it('updates the status class when setting an error', function () {
+        const expected = 's-status-error';
+        indicator.setError('error');
+        expect(indicator.indicator.statusClass).toHaveBeenCalledWith(expected);
+    });
 });

--- a/dsn/src/DsnIndicatorSpec.js
+++ b/dsn/src/DsnIndicatorSpec.js
@@ -73,4 +73,10 @@ describe('DsnIndicator', function () {
         indicator.setError('error');
         expect(indicator.indicator.statusClass).toHaveBeenCalledWith(expected);
     });
+
+    it('updates the description when setting an error', function () {
+        const expected = 'error';
+        indicator.setError(expected);
+        expect(indicator.indicator.description).toHaveBeenCalledWith(expected);
+    });
 });

--- a/dsn/src/DsnIndicatorSpec.js
+++ b/dsn/src/DsnIndicatorSpec.js
@@ -25,4 +25,9 @@ describe('DsnIndicator', function () {
         const status = indicator.formatAntennaStatus('Goldstone', ['dss14']);
         expect(status).toEqual('Goldstone: 1 (DSS 14)');
     });
+
+    it('formats status with multiple active antennas', function () {
+        const status = indicator.formatAntennaStatus('Madrid', ['dss54', 'dss55', 'dss63']);
+        expect(status).toEqual('Madrid: 3 (DSS 54, DSS 55, DSS 63)');
+    });
 });

--- a/dsn/src/DsnIndicatorSpec.js
+++ b/dsn/src/DsnIndicatorSpec.js
@@ -20,4 +20,9 @@ describe('DsnIndicator', function () {
         const status = indicator.formatAntennaStatus('Canberra', []);
         expect(status).toEqual('Canberra: 0');
     });
+
+    it('formats status with one active antenna', function () {
+        const status = indicator.formatAntennaStatus('Goldstone', ['dss14']);
+        expect(status).toEqual('Goldstone: 1 (DSS 14)');
+    });
 });

--- a/dsn/src/DsnIndicatorSpec.js
+++ b/dsn/src/DsnIndicatorSpec.js
@@ -5,6 +5,7 @@ describe('DsnIndicator', function () {
     const simpleIndicator = {
         description: jasmine.createSpy(),
         iconClass: jasmine.createSpy(),
+        statusClass: jasmine.createSpy(),
         text: jasmine.createSpy()
     };
 
@@ -53,5 +54,11 @@ describe('DsnIndicator', function () {
     it('finds multiple active antennas', function () {
         const activeAntennas = indicator.getActiveAntennas(dsn, MADRID_ANTENNAS);
         expect(activeAntennas).toEqual(['dss54', 'dss55']);
+    });
+
+    it('updates the status class when setting active antennas', function () {
+        const expected = 's-status-ok';
+        indicator.setActiveAntennas(dsn);
+        expect(indicator.indicator.statusClass).toHaveBeenCalledWith(expected);
     });
 });

--- a/dsn/src/DsnIndicatorSpec.js
+++ b/dsn/src/DsnIndicatorSpec.js
@@ -1,5 +1,5 @@
 import DsnIndicator from './DsnIndicator.js';
-import { CANBERRA_ANTENNAS } from './constants.js';
+import { CANBERRA_ANTENNAS, GOLDSTONE_ANTENNAS } from './constants.js';
 
 describe('DsnIndicator', function () {
     const simpleIndicator = {
@@ -43,5 +43,10 @@ describe('DsnIndicator', function () {
     it('finds no active antennas', function () {
         const activeAntennas = indicator.getActiveAntennas(dsn, CANBERRA_ANTENNAS);
         expect(activeAntennas).toEqual([]);
+    });
+
+    it('finds one active antenna', function () {
+        const activeAntennas = indicator.getActiveAntennas(dsn, GOLDSTONE_ANTENNAS);
+        expect(activeAntennas).toEqual(['dss25']);
     });
 });

--- a/dsn/src/DsnIndicatorSpec.js
+++ b/dsn/src/DsnIndicatorSpec.js
@@ -1,0 +1,23 @@
+import DsnIndicator from './DsnIndicator.js';
+
+describe('DsnIndicator', function () {
+    const simpleIndicator = {
+        description: jasmine.createSpy(),
+        iconClass: jasmine.createSpy(),
+        text: jasmine.createSpy()
+    };
+
+    const openmct = jasmine.createSpyObj('openmct', ['indicators']);
+    openmct.indicators = jasmine.createSpyObj('indicators', ['simpleIndicator']);
+    openmct.indicators.simpleIndicator = jasmine.createSpy().and.callFake(() => simpleIndicator);
+    let indicator;
+
+    beforeEach(function () {
+        indicator = new DsnIndicator(openmct);
+    });
+
+    it('formats status with no active antennas', function () {
+        const status = indicator.formatAntennaStatus('Canberra', []);
+        expect(status).toEqual('Canberra: 0');
+    });
+});

--- a/dsn/src/DsnIndicatorSpec.js
+++ b/dsn/src/DsnIndicatorSpec.js
@@ -1,4 +1,5 @@
 import DsnIndicator from './DsnIndicator.js';
+import { CANBERRA_ANTENNAS } from './constants.js';
 
 describe('DsnIndicator', function () {
     const simpleIndicator = {
@@ -10,7 +11,15 @@ describe('DsnIndicator', function () {
     const openmct = jasmine.createSpyObj('openmct', ['indicators']);
     openmct.indicators = jasmine.createSpyObj('indicators', ['simpleIndicator']);
     openmct.indicators.simpleIndicator = jasmine.createSpy().and.callFake(() => simpleIndicator);
+
     let indicator;
+    const dsn = {
+        data: {
+            'dss25.signals': [{}],
+            'dss54.signals': [{}],
+            'dss55.signals': [{}, {}]
+        }
+    };
 
     beforeEach(function () {
         indicator = new DsnIndicator(openmct);
@@ -29,5 +38,10 @@ describe('DsnIndicator', function () {
     it('formats status with multiple active antennas', function () {
         const status = indicator.formatAntennaStatus('Madrid', ['dss54', 'dss55', 'dss63']);
         expect(status).toEqual('Madrid: 3 (DSS 54, DSS 55, DSS 63)');
+    });
+
+    it('finds no active antennas', function () {
+        const activeAntennas = indicator.getActiveAntennas(dsn, CANBERRA_ANTENNAS);
+        expect(activeAntennas).toEqual([]);
     });
 });

--- a/dsn/src/DsnIndicatorSpec.js
+++ b/dsn/src/DsnIndicatorSpec.js
@@ -1,5 +1,5 @@
 import DsnIndicator from './DsnIndicator.js';
-import { CANBERRA_ANTENNAS, GOLDSTONE_ANTENNAS } from './constants.js';
+import { CANBERRA_ANTENNAS, GOLDSTONE_ANTENNAS, MADRID_ANTENNAS } from './constants.js';
 
 describe('DsnIndicator', function () {
     const simpleIndicator = {
@@ -48,5 +48,10 @@ describe('DsnIndicator', function () {
     it('finds one active antenna', function () {
         const activeAntennas = indicator.getActiveAntennas(dsn, GOLDSTONE_ANTENNAS);
         expect(activeAntennas).toEqual(['dss25']);
+    });
+
+    it('finds multiple active antennas', function () {
+        const activeAntennas = indicator.getActiveAntennas(dsn, MADRID_ANTENNAS);
+        expect(activeAntennas).toEqual(['dss54', 'dss55']);
     });
 });

--- a/dsn/src/DsnTelemetryProvider.js
+++ b/dsn/src/DsnTelemetryProvider.js
@@ -2,8 +2,9 @@ import { DSN_TELEMETRY_TYPE } from './constants.js';
 import { getDsnData } from './dsn-requests.js';
 
 class DsnTelemetryProvider {
-    constructor(config) {
+    constructor(config, indicator) {
         this.config = config;
+        this.indicator = indicator;
     }
 
     provideTelemetry(dsn, domainObject, callback) {
@@ -34,6 +35,7 @@ class DsnTelemetryProvider {
 
     subscribe(domainObject, callback, options) {
         const config = this.config;
+        const indicator = this.indicator;
         const listeners = {};
         const provideTelemetry = this.provideTelemetry;
 
@@ -49,6 +51,10 @@ class DsnTelemetryProvider {
             getDsnData(config)
                 .then(dsn => {
                     provideTelemetry(dsn, domainObject, callback);
+                    indicator.setActiveAntennas(dsn);
+                })
+                .catch(error => {
+                    indicator.setError(error);
                 });
         }, 5000);
 

--- a/dsn/src/constants.js
+++ b/dsn/src/constants.js
@@ -1,5 +1,8 @@
+export const CANBERRA_ANTENNAS = ['dss34', 'dss35', 'dss36', 'dss43'];
 export const DSN_CONFIG_SOURCE = 'https://eyes.nasa.gov/dsn/config.xml';
 export const DSN_KEY = 'dsn';
 export const DSN_NAMESPACE = 'deep.space.network';
 export const DSN_TELEMETRY_SOURCE = 'https://eyes.nasa.gov/dsn/data/dsn.xml';
 export const DSN_TELEMETRY_TYPE = 'dsn.telemetry';
+export const GOLDSTONE_ANTENNAS = ['dss14', 'dss24', 'dss25', 'dss26'];
+export const MADRID_ANTENNAS = ['dss54', 'dss55', 'dss56', 'dss63', 'dss65'];

--- a/dsn/src/dsn-requests.js
+++ b/dsn/src/dsn-requests.js
@@ -24,7 +24,10 @@ export function getDsnConfiguration() {
         .then(checkFetchStatus)
         .then(response => response.text())
         .then(parseResponse)
-        .catch(error => console.error('Error fetching DSN config: ', error));
+        .catch(error => {
+            console.error('Error fetching DSN config: ', error);
+            throw error;
+        });
 }
 
 export function getDsnData(config) {
@@ -35,5 +38,8 @@ export function getDsnData(config) {
         .then(checkFetchStatus)
         .then(response => response.text())
         .then(responseText => parseResponse(responseText, config))
-        .catch(error => console.error('Error fetching DSN data: ', error));
+        .catch(error => {
+            console.error('Error fetching DSN data: ', error);
+            throw error;
+        });
 }

--- a/dsn/src/plugin.js
+++ b/dsn/src/plugin.js
@@ -14,6 +14,7 @@ import {
     windSpeedToString
 } from './dsn-formatters.js';
 
+import DsnIndicator from './DsnIndicator.js';
 import DsnTelemetryProvider from './DsnTelemetryProvider.js';
 import { objectProvider } from './dsn-object-provider.js';
 import { getDsnConfiguration } from './dsn-requests.js';
@@ -38,8 +39,14 @@ export default function DsnPlugin() {
         openmct.telemetry.addFormat(rangeToString);
         openmct.telemetry.addFormat(lightTimeToString);
 
+        const antennaIndicator = new DsnIndicator(openmct);
+        openmct.indicators.add(antennaIndicator.indicator);
+
         getDsnConfiguration()
-            .then(dsn => openmct.telemetry.addProvider(new DsnTelemetryProvider(dsn.data)));
+            .then(dsn => openmct.telemetry.addProvider(new DsnTelemetryProvider(dsn.data, antennaIndicator)))
+            .catch(error => {
+                antennaIndicator.setError(error);
+            });
 
         openmct.objects.addProvider(DSN_NAMESPACE, objectProvider);
 


### PR DESCRIPTION
This pull request adds an indicator to help users identify which antennas are sending or receiving signals.

### Initial
The initial state will prompt to select a telemetry item to fetch data.

<img width="205" alt="Screen Shot 2021-11-14 at 10 04 14 pm" src="https://user-images.githubusercontent.com/2645932/141678383-370543b4-6b3c-4ea4-bd2e-0c1481b64003.png">

### Success
When data is successfully received from the Deep Space Network, the indicator will be updated with a summary of which antennas are active and have signal data associated with them.

<img width="270" alt="Screen Shot 2021-11-14 at 10 04 54 pm" src="https://user-images.githubusercontent.com/2645932/141678385-f711907b-9e37-4f72-9c60-32437c2cf87c.png">

### Error
If an error is thrown getting or parsing data from the Deep Space Network then this will be reflected with a different style and a message about the error that occurred.

<img width="188" alt="Screen Shot 2021-11-14 at 10 06 46 pm" src="https://user-images.githubusercontent.com/2645932/141678387-73441469-c305-439d-b010-959b95a9256a.png">
