### PR TITLE
Use a spy object to represent the indicator

### DIFF
--- a/dsn/src/DsnTelemetryProviderSpec.js
+++ b/dsn/src/DsnTelemetryProviderSpec.js
@@ -12,6 +12,7 @@ describe('DsnTelemetryProvider', function () {
     let dsn;
     let dsnParser;
     let dsnXml;
+    let indicator;
     let telemetryProvider;
 
     const signalsDomainObject = {
@@ -136,7 +137,8 @@ describe('DsnTelemetryProvider', function () {
         dsnXml = domParser.parseFromString(testXmlResponse, 'application/xml');
         dsn = dsnParser.parseXml(dsnXml);
 
-        telemetryProvider = new DsnTelemetryProvider(dsn);
+        indicator = jasmine.createSpyObj('indicator', ['setError']);
+        telemetryProvider = new DsnTelemetryProvider(dsn, indicator);
     });
 
     afterEach(function () {


### PR DESCRIPTION
This pull request fixes the following error which occurs when executing tests in openmct.

>TypeError: Cannot read properties of undefined (reading 'setError')