### PR TITLE
Remove the use of proxyUrl

### DIFF
--- a/dsn/src/dsn-requests.js
+++ b/dsn/src/dsn-requests.js
@@ -18,9 +18,7 @@ function parseResponse(responseText, config) {
 }
 
 export function getDsnConfiguration() {
-    const url = '/proxyUrl?url=' + encodeURIComponent(DSN_CONFIG_SOURCE);
-
-    return fetch(url)
+    return fetch(DSN_CONFIG_SOURCE)
         .then(checkFetchStatus)
         .then(response => response.text())
         .then(parseResponse)
@@ -32,7 +30,7 @@ export function getDsnConfiguration() {
 
 export function getDsnData(config) {
     // Add the same query string parameter the DSN site sends with each request
-    const url = '/proxyUrl?url=' + encodeURIComponent(DSN_TELEMETRY_SOURCE + '?r=' + Math.floor(new Date().getTime() / 5000));
+    const url = DSN_TELEMETRY_SOURCE + '?r=' + Math.floor(new Date().getTime() / 5000);
 
     return fetch(url)
         .then(checkFetchStatus)


### PR DESCRIPTION
This pull request removes the use of `proxyUrl` which is prefixed before DSN config and telemetry source URLs.  This was defined upstream but no longer exists.